### PR TITLE
Feature/remove toml precommit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,11 +11,6 @@ repos:
         args: [--fix] # To enable lint fixes
       # Run the formatter using configs in pyproject.toml
       - id: ruff-format
-  # pyproject-fmt for formatting toml files
-  - repo: https://github.com/tox-dev/pyproject-fmt
-    rev: v2.6.0
-    hooks:
-      - id: pyproject-fmt
   # yamlfmt for formatting YAML files
   - repo: https://github.com/google/yamlfmt
     rev: v0.17.2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,13 +31,13 @@ dependencies = [
   "stanza",
 ]
 
-optional-dependencies.dev = [
+[project.optional-dependencies]
+dev = [
   "pre-commit",
   "remarx[test]",
   "ruff",
 ]
-#[project.scripts]
-optional-dependencies.test = [
+test = [
   "pytest",
   "pytest-cov",
 ]


### PR DESCRIPTION
**Associated Issue(s):** #155 

### Changes in this PR
- Removed toml pre-commit hook from `.pre-commit-config.yaml`
- Refactor `pyproject.toml` file to follow the team's preferred format

### Reviewer Checklist
@laurejt 
- [ ] toml pre-commit hook has beed removed
- [ ] `pyproject.toml` file is following conventions; otherwise, suggest changes
