### PR TITLE
pre-commit hook for uv.lock

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -35,3 +35,9 @@ repos:
       - id: trailing-whitespace
       - id: end-of-file-fixer
       - id: check-merge-conflict
+  # Make sure uv.lock file is up to date
+  - repo: https://github.com/astral-sh/uv-pre-commit
+    # uv version.
+    rev: 0.8.6
+    hooks:
+      - id: uv-lock


### PR DESCRIPTION
**Associated Issue(s):** #159 

### Changes in this PR
- Adds new pre-commit hook to check that the `uv.lock` file is up to date.

### Notes

### Reviewer Checklist

@tanhaow 
- [x] Verify the pre-commit hook runs locally

@rlskoeser 
- [x] Verify the pre-commit hook runs locally
