### PR TITLE
Specify download reuse for stanza resources for sentence segmentation

### DIFF
--- a/src/remarx/sentence/segment.py
+++ b/src/remarx/sentence/segment.py
@@ -5,6 +5,7 @@ sentence begins and the sentence text itself.
 """
 
 import stanza
+from stanza import DownloadMethod
 
 
 def segment_text(text: str, language: str = "de") -> list[tuple[int, str]]:
@@ -17,7 +18,11 @@ def segment_text(text: str, language: str = "de") -> list[tuple[int, str]]:
     """
     # Initialize the NLP pipeline for sentence segmentation
     # Use minimal processors (tokenize) for sentence segmentation only
-    segmenter = stanza.Pipeline(lang=language, processors="tokenize")
+    segmenter = stanza.Pipeline(
+        lang=language,
+        processors="tokenize",
+        download_method=DownloadMethod.REUSE_RESOURCES,
+    )
 
     processed_doc = segmenter(text)
 

--- a/tests/test_sentence/test_segment.py
+++ b/tests/test_sentence/test_segment.py
@@ -4,7 +4,7 @@ Unit tests for sentence segmentation functionality.
 
 from unittest.mock import Mock, patch
 
-from stanza import Pipeline
+from stanza import DownloadMethod, Pipeline
 from stanza.models.common.doc import Document, Sentence
 
 from remarx.sentence.segment import segment_text
@@ -65,11 +65,19 @@ class TestSegmentTextIntoSentences:
 
         # Test with explicit "en" language
         segment_text("Hello world.", language="en")
-        mock_pipeline_class.assert_called_with(lang="en", processors="tokenize")
+        mock_pipeline_class.assert_called_with(
+            lang="en",
+            processors="tokenize",
+            download_method=DownloadMethod.REUSE_RESOURCES,
+        )
 
         # Reset mock for second test
         mock_pipeline_class.reset_mock()
 
         # Test with default language (should be "de")
         segment_text("Hallo Welt.")
-        mock_pipeline_class.assert_called_with(lang="de", processors="tokenize")
+        mock_pipeline_class.assert_called_with(
+            lang="de",
+            processors="tokenize",
+            download_method=DownloadMethod.REUSE_RESOURCES,
+        )


### PR DESCRIPTION
**Associated Issue:**  ~ 

### Changes in this PR

- Configure sentence segment method to reuse stanza resources instead of checking every time on pipeline init

### Notes

- This is to partially address the slowness we're seeing when segmenting the full MEGA TEI
- I could have sworn we had this in the first version of the segmentation implementation! Must have gotten lost when we simplified on the refactor.
