### PR TITLE
Add GitHub actions to check mkdocs build and ruff style

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches: [develop, main]
   # Allow running manually
-  on: workflow_dispatch
+  workflow_dispatch:
 jobs:
   check_docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,0 +1,29 @@
+name: Check docs + style
+on:
+  # Run on pull requests to develop or main
+  pull_request:
+    branches: [develop, main]
+  # Allow running manually
+  on: workflow_dispatch
+jobs:
+  check_docs:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install dependencies for building docs
+        run: uv sync --extra docs
+      - name: Check that documentation builds with no errors or warnings
+        run: uv run mkdocs build --strict
+  check_style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install uv
+        uses: astral-sh/setup-uv@v6
+      - name: Install package with dependencies
+        run: uv sync
+        # Note: default deps currently include ruff, but probably should not
+      - name: Check with ruff
+        run: uv run ruff check

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -6,7 +6,7 @@ on:
   # Allow running manually
   workflow_dispatch:
 jobs:
-  check_docs:
+  docs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -16,7 +16,7 @@ jobs:
         run: uv sync --extra docs
       - name: Check that documentation builds with no errors or warnings
         run: uv run mkdocs build --strict
-  check_style:
+  style:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -11,16 +11,9 @@ jobs:
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies
-        run: |
-          uv sync --extra dev --extra test
+        run: uv sync --extra dev --extra test
       - name: Run tests with coverage
-        run: |
-          uv run pytest \
-            --cov=src/remarx \
-            --cov=tests \
-            --cov-report=xml \
-            --cov-report=term \
-            tests
+        run: uv run pytest --cov=remarx  --cov=tests --cov-report=xml --cov-report=term
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5
         with:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -1,4 +1,4 @@
-name: Unit Tests & Code Coverage
+name: Unit Tests
 on:
   push: # Run on all branches
   pull_request:

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -6,17 +6,12 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        uv-version: ["0.8.6"]
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python
         uses: actions/setup-python@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v6
-        with:
-          version: ${{ matrix.uv-version }}
       - name: Install dependencies
         run: |
           uv sync --extra dev --extra test

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -8,8 +8,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python
-        uses: actions/setup-python@v5
       - name: Install uv
         uses: astral-sh/setup-uv@v6
       - name: Install dependencies

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     rev: v0.12.7
     hooks:
       # Run the linter
-      - id: ruff
+      - id: ruff-check
         args: [--fix] # To enable lint fixes
       # Run the formatter using configs in pyproject.toml
       - id: ruff-format

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ The primary purpose of this software is to identify quotes of Karl Marx's _Manif
 der Kommunistischen Partei_ and the first volume of _Das Kapital_ within articles
 published in _Die Neue Zeit_ between 1891 and 1918.
 
+[![Unit Tests](https://github.com/Princeton-CDH/remarx/actions/workflows/unit_tests.yml/badge.svg)](https://github.com/Princeton-CDH/remarx/actions/workflows/unit_tests.yml)
+
 ## Basic Usage
 
 ### Installation

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -128,3 +128,6 @@ lsp = true
 [tool.hatch.metadata]
 # So python type stubs can be installed from GitHub (i.e., direct reference)
 allow-direct-references = true
+
+[tool.uv]
+required-version = ">=0.8.6"


### PR DESCRIPTION
**Associated Issue(s):** #163 

### Changes in this PR

- Set minimum uv version in pyproject.toml and remove from unit test workflow
- Simplified unit test workflow (python setup is included in uv setup)
- Add new workflow to check docs and ruff formatting
- Shorten unit test workflow name and add status badge to readme

### Notes

- After Laure caught a cross-reference that was causing a problem, I thought it would be important to have an automated check to flag these for us. This is adapted in part from a similar check on my undate project.
- I've configured the check workflow to run on PRs and manually only, thought that would be enough; let me know if you think we should add/modify triggers.
- No review checklist items other than reviewing the code changes