### PR TITLE
Update base output fields so sentence index is included in sentence csv

### DIFF
--- a/src/remarx/sentence/corpus/base_input.py
+++ b/src/remarx/sentence/corpus/base_input.py
@@ -32,7 +32,7 @@ class FileInput:
     input_file: pathlib.Path
     "Reference to input file. Source of content for sentences."
 
-    field_names: ClassVar[tuple[str, ...]] = ("file", "offset", "text")
+    field_names: ClassVar[tuple[str, ...]] = ("file", "sent_index", "text")
     "List of field names for sentences from text input files."
 
     file_type: ClassVar[str]

--- a/tests/test_sentence/test_corpus/test_base_input.py
+++ b/tests/test_sentence/test_corpus/test_base_input.py
@@ -36,7 +36,7 @@ def test_file_name_override(tmp_path: pathlib.Path):
 
 
 def test_field_names(tmp_path: pathlib.Path):
-    assert FileInput.field_names == ("file", "offset", "text")
+    assert FileInput.field_names == ("file", "sent_index", "text")
 
 
 def test_supported_types():

--- a/tests/test_sentence/test_corpus/test_tei_input.py
+++ b/tests/test_sentence/test_corpus/test_tei_input.py
@@ -79,7 +79,7 @@ class TestTEIinput:
 
     def test_field_names(self, tmp_path: pathlib.Path):
         # includes defaults from text input and adds page number
-        assert TEIinput.field_names == ("file", "offset", "text", "page_number")
+        assert TEIinput.field_names == ("file", "sent_index", "text", "page_number")
 
     def test_get_text(self):
         tei_input = TEIinput(input_file=TEST_TEI_FILE)

--- a/tests/test_sentence/test_corpus/test_text_input.py
+++ b/tests/test_sentence/test_corpus/test_text_input.py
@@ -19,7 +19,7 @@ def test_file_name(tmp_path: pathlib.Path):
 
 
 def test_field_names(tmp_path: pathlib.Path):
-    assert TextInput.field_names == ("file", "offset", "text")
+    assert TextInput.field_names == ("file", "sent_index", "text")
 
 
 def test_get_text(tmp_path: pathlib.Path):


### PR DESCRIPTION
**Associated Issue:** #122

### Changes in this PR

- Update base input class with the correct field names (replace `offset` with `sent_index`)
- Update unit tests to match the change