### PR TITLE
Add, test, and use an option to override input file name for sentence corpus creation

### DIFF
--- a/src/remarx/app.py
+++ b/src/remarx/app.py
@@ -89,12 +89,7 @@ def _(mo, select_input):
     input_callout_type = "success" if input_file else "warn"
 
     mo.callout(
-        mo.vstack(
-            [
-                select_input,
-                mo.md(f"**Input File:** {input_file_msg}")
-            ]
-        ),
+        mo.vstack([select_input, mo.md(f"**Input File:** {input_file_msg}")]),
         kind=input_callout_type,
     )
     return (input_file,)
@@ -213,7 +208,9 @@ def _(button, create_corpus, create_temp_input, input_file, mo, output_csv):
         spinner_msg = f"Building sentence corpus for {input_file.name}"
         with mo.status.spinner(title=spinner_msg) as _spinner:
             with create_temp_input(input_file) as temp_path:
-                create_corpus(temp_path, output_csv)
+                create_corpus(
+                    temp_path, output_csv, filename_override=input_file.name
+                )
         building_msg = f"✅ Sentence corpus saved to: {output_csv}"
 
     mo.md(building_msg).center()

--- a/src/remarx/sentence/corpus/base_input.py
+++ b/src/remarx/sentence/corpus/base_input.py
@@ -112,10 +112,13 @@ class FileInput:
         return list({subcls.file_type for subcls in cls.subclasses()})
 
     @classmethod
-    def init(cls, input_file: pathlib.Path) -> Self:
+    def init(
+        cls, input_file: pathlib.Path, filename_override: str | None = None
+    ) -> Self:
         """
         Instantiate and return the appropriate input class for the specified
-        input file.
+        input file.  Takes an optional filename override parameter,
+        which is passed through to the input class.
 
         :raises ValueError: if input_file is not a supported type
         """
@@ -129,4 +132,4 @@ class FileInput:
             raise ValueError(
                 f"{input_file.suffix} is not a supported input type (must be one of {supported_types})"
             )
-        return input_cls(input_file=input_file)
+        return input_cls(input_file=input_file, filename_override=filename_override)

--- a/src/remarx/sentence/corpus/base_input.py
+++ b/src/remarx/sentence/corpus/base_input.py
@@ -112,7 +112,7 @@ class FileInput:
         return list({subcls.file_type for subcls in cls.subclasses()})
 
     @classmethod
-    def init(
+    def create(
         cls, input_file: pathlib.Path, filename_override: str | None = None
     ) -> Self:
         """

--- a/src/remarx/sentence/corpus/base_input.py
+++ b/src/remarx/sentence/corpus/base_input.py
@@ -4,7 +4,7 @@ method for initialization of known input classes based on supported
 file types.
 
 To initialize the appropriate subclass for a supported file type,
-use [FileInput.init()][remarx.sentence.corpus.base_input.FileInput.init].
+use [FileInput.create()][remarx.sentence.corpus.base_input.FileInput.create].
 
 For a list of supported file types across all registered input classes,
 use [FileInput.supported_types()][remarx.sentence.corpus.base_input.FileInput.supported_types].

--- a/src/remarx/sentence/corpus/base_input.py
+++ b/src/remarx/sentence/corpus/base_input.py
@@ -32,6 +32,9 @@ class FileInput:
     input_file: pathlib.Path
     "Reference to input file. Source of content for sentences."
 
+    filename_override: str = None
+    "Optional filename override, e.g. when using temporary files as input"
+
     field_names: ClassVar[tuple[str, ...]] = ("file", "offset", "text")
     "List of field names for sentences from text input files."
 
@@ -43,7 +46,7 @@ class FileInput:
         """
         Input file name. Associated with sentences in generated corpus.
         """
-        return self.input_file.name
+        return self.filename_override or self.input_file.name
 
     def get_text(self) -> Generator[dict[str, str]]:
         """

--- a/src/remarx/sentence/corpus/create.py
+++ b/src/remarx/sentence/corpus/create.py
@@ -32,7 +32,7 @@ def create_corpus(
     if not input_file.is_file():
         raise ValueError(f"Input file {input_file} does not exist")
 
-    text_input = FileInput.init(input_file, filename_override=filename_override)
+    text_input = FileInput.create(input_file, filename_override=filename_override)
     field_names = text_input.field_names
 
     with output_csv.open(mode="w", newline="") as csvfile:

--- a/src/remarx/sentence/corpus/create.py
+++ b/src/remarx/sentence/corpus/create.py
@@ -17,7 +17,11 @@ import pathlib
 from remarx.sentence.corpus.base_input import FileInput
 
 
-def create_corpus(input_file: pathlib.Path, output_csv: pathlib.Path) -> None:
+def create_corpus(
+    input_file: pathlib.Path,
+    output_csv: pathlib.Path,
+    filename_override: str | None = None,
+) -> None:
     """
     Create and save a sentence corpus from the provided input file to the
     provided output path `output_csv`.
@@ -28,7 +32,7 @@ def create_corpus(input_file: pathlib.Path, output_csv: pathlib.Path) -> None:
     if not input_file.is_file():
         raise ValueError(f"Input file {input_file} does not exist")
 
-    text_input = FileInput.init(input_file)
+    text_input = FileInput.init(input_file, filename_override=filename_override)
     field_names = text_input.field_names
 
     with output_csv.open(mode="w", newline="") as csvfile:

--- a/tests/test_sentence/test_corpus/test_base_input.py
+++ b/tests/test_sentence/test_corpus/test_base_input.py
@@ -73,6 +73,16 @@ def test_init_exts(tmp_path: pathlib.Path):
     assert isinstance(txt_input, TextInput)
 
 
+def test_init_filename_override(tmp_path: pathlib.Path):
+    from remarx.sentence.corpus.text_input import TextInput
+
+    txt_file = tmp_path / "tmp_foo_bar_input.txt"
+    real_filename = "input.txt"
+    txt_input = FileInput.init(input_file=txt_file, filename_override=real_filename)
+    assert isinstance(txt_input, TextInput)
+    assert txt_input.file_name == real_filename
+
+
 @patch("remarx.sentence.corpus.tei_input.TEIDocument")
 def test_init_tei(mock_tei_doc, tmp_path: pathlib.Path):
     from remarx.sentence.corpus.tei_input import TEIinput

--- a/tests/test_sentence/test_corpus/test_base_input.py
+++ b/tests/test_sentence/test_corpus/test_base_input.py
@@ -15,6 +15,30 @@ def test_subclasses():
         assert input_cls_name in subclass_names
 
 
+def test_init(tmp_path: pathlib.Path):
+    txt_file = tmp_path / "input.txt"
+    txt_input = FileInput(input_file=txt_file)
+    assert txt_input.input_file == txt_file
+
+
+def test_file_name(tmp_path: pathlib.Path):
+    txt_filename = "my_input.txt"
+    txt_file = tmp_path / txt_filename
+    txt_input = FileInput(input_file=txt_file)
+    assert txt_input.file_name == txt_filename
+
+
+def test_file_name_override(tmp_path: pathlib.Path):
+    real_txt_filename = "my_input.txt"
+    txt_file = tmp_path / "tmp_abc_input_foo.txt"
+    txt_input = FileInput(input_file=txt_file, filename_override=real_txt_filename)
+    assert txt_input.file_name == real_txt_filename
+
+
+def test_field_names(tmp_path: pathlib.Path):
+    assert FileInput.field_names == ("file", "offset", "text")
+
+
 def test_supported_types():
     # check for expected supported types
     # NOTE: checking directly to avoid importing input classes

--- a/tests/test_sentence/test_corpus/test_base_input.py
+++ b/tests/test_sentence/test_corpus/test_base_input.py
@@ -53,50 +53,50 @@ def test_get_text(tmp_path: pathlib.Path):
         base_input.get_text()
 
 
-def test_init_txt(tmp_path: pathlib.Path):
+def test_create_txt(tmp_path: pathlib.Path):
     from remarx.sentence.corpus.text_input import TextInput
 
     txt_file = tmp_path / "input.txt"
-    txt_input = FileInput.init(input_file=txt_file)
+    txt_input = FileInput.create(input_file=txt_file)
     assert isinstance(txt_input, TextInput)
 
 
-def test_init_exts(tmp_path: pathlib.Path):
+def test_create_exts(tmp_path: pathlib.Path):
     from remarx.sentence.corpus.text_input import TextInput
 
     txt_file = tmp_path / "upper.TXT"
-    txt_input = FileInput.init(input_file=txt_file)
+    txt_input = FileInput.create(input_file=txt_file)
     assert isinstance(txt_input, TextInput)
 
     txt_file = tmp_path / "mixed.TxT"
-    txt_input = FileInput.init(input_file=txt_file)
+    txt_input = FileInput.create(input_file=txt_file)
     assert isinstance(txt_input, TextInput)
 
 
-def test_init_filename_override(tmp_path: pathlib.Path):
+def test_create_filename_override(tmp_path: pathlib.Path):
     from remarx.sentence.corpus.text_input import TextInput
 
     txt_file = tmp_path / "tmp_foo_bar_input.txt"
     real_filename = "input.txt"
-    txt_input = FileInput.init(input_file=txt_file, filename_override=real_filename)
+    txt_input = FileInput.create(input_file=txt_file, filename_override=real_filename)
     assert isinstance(txt_input, TextInput)
     assert txt_input.file_name == real_filename
 
 
 @patch("remarx.sentence.corpus.tei_input.TEIDocument")
-def test_init_tei(mock_tei_doc, tmp_path: pathlib.Path):
+def test_create_tei(mock_tei_doc, tmp_path: pathlib.Path):
     from remarx.sentence.corpus.tei_input import TEIinput
 
     xml_input_file = tmp_path / "input.xml"
-    xml_input = FileInput.init(input_file=xml_input_file)
+    xml_input = FileInput.create(input_file=xml_input_file)
     assert isinstance(xml_input, TEIinput)
     mock_tei_doc.init_from_file.assert_called_with(xml_input_file)
 
 
-def test_init_unsupported(tmp_path: pathlib.Path):
+def test_create_unsupported(tmp_path: pathlib.Path):
     test_file = tmp_path / "input.test"
     with pytest.raises(
         ValueError,
         match="\\.test is not a supported input type \\(must be one of \\.txt, \\.xml\\)",
     ):
-        FileInput.init(input_file=test_file)
+        FileInput.create(input_file=test_file)

--- a/tests/test_sentence/test_corpus/test_create.py
+++ b/tests/test_sentence/test_corpus/test_create.py
@@ -34,9 +34,22 @@ def test_create_corpus(mock_file_input, tmp_path: pathlib.Path):
     create_corpus(input_file, out_csv)
 
     assert out_csv.is_file()
-    mock_file_input.init.assert_called_once_with(input_file)
+    mock_file_input.init.assert_called_once_with(input_file, filename_override=None)
     mock_input.get_sentences.assert_called_once_with()
     assert out_csv.read_text() == "some,field,names\na,b,c\n1,2,3\n"
+
+
+@patch("remarx.sentence.corpus.create.FileInput")
+def test_create_corpus_filename_override(mock_file_input, tmp_path: pathlib.Path):
+    # test that filename override is passed through
+    input_file = tmp_path / "tmp_foo_input_bar.txt"
+    input_file.touch()
+    out_csv = tmp_path / "out.csv"
+    real_filename = "input.txt"
+    create_corpus(input_file, out_csv, filename_override=real_filename)
+    mock_file_input.init.assert_called_once_with(
+        input_file, filename_override=real_filename
+    )
 
 
 @patch("remarx.sentence.corpus.create.create_corpus")

--- a/tests/test_sentence/test_corpus/test_create.py
+++ b/tests/test_sentence/test_corpus/test_create.py
@@ -24,7 +24,7 @@ def test_create_corpus(mock_file_input, tmp_path: pathlib.Path):
     out_csv = tmp_path / "out.csv"
     ## Mock input text
     mock_input = Mock()
-    mock_file_input.init.return_value = mock_input
+    mock_file_input.create.return_value = mock_input
     mock_input.field_names = ["some", "field", "names"]
     mock_input.get_sentences.return_value = [
         {"some": "a", "field": "b", "names": "c"},
@@ -34,7 +34,7 @@ def test_create_corpus(mock_file_input, tmp_path: pathlib.Path):
     create_corpus(input_file, out_csv)
 
     assert out_csv.is_file()
-    mock_file_input.init.assert_called_once_with(input_file, filename_override=None)
+    mock_file_input.create.assert_called_once_with(input_file, filename_override=None)
     mock_input.get_sentences.assert_called_once_with()
     assert out_csv.read_text() == "some,field,names\na,b,c\n1,2,3\n"
 
@@ -47,7 +47,7 @@ def test_create_corpus_filename_override(mock_file_input, tmp_path: pathlib.Path
     out_csv = tmp_path / "out.csv"
     real_filename = "input.txt"
     create_corpus(input_file, out_csv, filename_override=real_filename)
-    mock_file_input.init.assert_called_once_with(
+    mock_file_input.create.assert_called_once_with(
         input_file, filename_override=real_filename
     )
 

--- a/tests/test_sentence/test_corpus/test_text_input.py
+++ b/tests/test_sentence/test_corpus/test_text_input.py
@@ -62,7 +62,6 @@ def test_get_sentences(mock_segment_text: Mock, tmp_path: pathlib.Path):
     assert isinstance(sentences, Generator)
     # consume the generator
     sentences = list(sentences)
-    print(sentences)
     assert len(sentences) == 2
 
     # expect segmentation method to be called only once


### PR DESCRIPTION
**Associated Issue:** #122

### Changes in this PR

- Add optional filename override parameter to file input classes and all calling methods (factory method, corpus create)
- Update app code to pass in uploaded input file name to corpus create method
- Rename file input base class factory method from `init` to `create` to avoid confusion

### Notes

- Tried abstract base class for base file - works, but need a way to test the base functionality
- Tried adding logging to base class post init, but it seems to be inherited
- I tested manually from the app and confirmed that the original filename is preserved in the output
