### PR TITLE
Add additional corpus metadata to quote pairs CSV 

### DIFF
--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -217,7 +217,7 @@ A CSV file with each row corresponding to an original-reuse sentence pair that h
 | original_sent_index | Sentence-level index within original document | Integer  | Required                | For identifying sequential sentences for quote compilation |
 
 Additional metadata for the corresponding reuse and original sentences will be included depending on the contents of the input sentence corpora.
-This metadata of each corpus will follow its sentence index field (i.e., `reuse_sent_index`, `original_sent_index`).
+Each corpus's additional metadata fields will follow its sentence index field (i.e., `reuse_sent_index`, `original_sent_index`).
 
 #### Quotes Corpus
 

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -193,7 +193,7 @@ A CSV file with each row corresponding to a single sentence in either an origina
 | :------------- | :------------------------------------------------------------ | :------- | :---------------------- | :--------------------------------------------------------- |
 | id             | Unique identifier for each sentence                           | String   | Required                | For tracking, reference                                    |
 | text           | Sentence text content                                         | String   | Required                | For quote detection                                        |
-| doc            | Corresponding document filename                               | String   | Required                | For tracking, reference, metadata linking                  |
+| file           | Corresponding document filename                               | String   | Required                | For tracking, reference, metadata linking                  |
 | sent_index     | Sentence-level index within document (0-based indexing)       | Integer  | Required                | For identifying sequential sentences for quote compilation |
 | section_type   | What text section the sentence comes from (text vs. footnote) | enum     | Optional                | For reference and debugging                                |
 | multi_page     | Indicates whether the sentence spans multiple pages.          | Boolean  | Required                | For reference and debugging                                |
@@ -202,18 +202,23 @@ The sentence corpora produced by the Sentence Corpus Builder program must includ
 
 #### Quote Sentence Pairs
 
-A CSV file with each row corresponding to a original-reuse sentence pair that has been identified as a quote.
+A CSV file with each row corresponding to an original-reuse sentence pair that has been identified as a quote.
 
-| **Field Name** | **Description**               | **Type** | **Required / Optional** | **Reason**                  |
-| :------------- | :---------------------------- | :------- | :---------------------- | :-------------------------- |
-| reuse_id       | ID of the reuse text sentence | String   | Required                | For tracking, reference     |
-| original_id    | ID of the original sentence   | String   | Required                | For tracking, reference     |
-| match_score    | Some match quality score      | Float    | Required                | For development, evaluation |
+| **Field Name**      | **Description**                            | **Type** | **Required / Optional** | **Reason**                                                 |
+| :------------------ | :----------------------------------------- | :------- | :---------------------- | :--------------------------------------------------------- |
+| match_score         | Some match quality score                   | Float    | Required                | For development, evaluation                                |
+| reuse_id            | ID of the reuse text sentence              | String   | Required                | For tracking, reference                                    |
+| reuse_text          | Text of the reuse sentence                 | String   | Required                | For reference                                              |
+| reuse_file          | Reuse document filename                    | String   | Required                | For tracking, reference                                    |
+| reuse_sent_index    | Sentence-level index within reuse document | Integer  | Required                | For identifying sequential sentences for quote compilation |
+| original_id         | ID of the original sentence                | String   | Required                | For tracking, reference, metadata linking                  |
+| original_text       | Text of the original sentence              | String   | Required                | For reference                                              |
+| original_file       | Original document filename                 | String   | Required                | For tracking, reference, metadata linking                  |
+| original_sent_index | Sentence-level index within reuse document | Integer  | Required                | For identifying sequential sentences for quote compilation |
 
-Depending on performance and resource needs, this could be to include each sentence’s fields within the sentence corpus.
-
-- Resource: This increases storage use since there will be field duplication between multiple data files.
-- Performance: This would eliminate the computational overhead of gathering sentence-level data for quote compilation.
+Additional metadata for the corresponding reuse and original sentences will be included depending on the contents of the inoput sentence corpora.
+Additional reuse fields will follow `reuse_sent_index`.
+Additional original fields will follow `original_sent_index`.
 
 #### Quotes Corpus
 

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -216,9 +216,8 @@ A CSV file with each row corresponding to an original-reuse sentence pair that h
 | original_file       | Original document filename                    | String   | Required                | For tracking, reference, metadata linking                  |
 | original_sent_index | Sentence-level index within original document | Integer  | Required                | For identifying sequential sentences for quote compilation |
 
-Additional metadata for the corresponding reuse and original sentences will be included depending on the contents of the inoput sentence corpora.
-Additional reuse fields will follow `reuse_sent_index`.
-Additional original fields will follow `original_sent_index`.
+Additional metadata for the corresponding reuse and original sentences will be included depending on the contents of the input sentence corpora.
+This metadata of each corpus will follow its sentence index field (i.e., `reuse_sent_index`, `original_sent_index`).
 
 #### Quotes Corpus
 

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -204,17 +204,17 @@ The sentence corpora produced by the Sentence Corpus Builder program must includ
 
 A CSV file with each row corresponding to an original-reuse sentence pair that has been identified as a quote.
 
-| **Field Name**      | **Description**                            | **Type** | **Required / Optional** | **Reason**                                                 |
-| :------------------ | :----------------------------------------- | :------- | :---------------------- | :--------------------------------------------------------- |
-| match_score         | Some match quality score                   | Float    | Required                | For development, evaluation                                |
-| reuse_id            | ID of the reuse text sentence              | String   | Required                | For tracking, reference                                    |
-| reuse_text          | Text of the reuse sentence                 | String   | Required                | For reference                                              |
-| reuse_file          | Reuse document filename                    | String   | Required                | For tracking, reference                                    |
-| reuse_sent_index    | Sentence-level index within reuse document | Integer  | Required                | For identifying sequential sentences for quote compilation |
-| original_id         | ID of the original sentence                | String   | Required                | For tracking, reference, metadata linking                  |
-| original_text       | Text of the original sentence              | String   | Required                | For reference                                              |
-| original_file       | Original document filename                 | String   | Required                | For tracking, reference, metadata linking                  |
-| original_sent_index | Sentence-level index within reuse document | Integer  | Required                | For identifying sequential sentences for quote compilation |
+| **Field Name**      | **Description**                               | **Type** | **Required / Optional** | **Reason**                                                 |
+| :------------------ | :-------------------------------------------- | :------- | :---------------------- | :--------------------------------------------------------- |
+| match_score         | Some match quality score                      | Float    | Required                | For development, evaluation                                |
+| reuse_id            | ID of the reuse text sentence                 | String   | Required                | For tracking, reference                                    |
+| reuse_text          | Text of the reuse sentence                    | String   | Required                | For reference                                              |
+| reuse_file          | Reuse document filename                       | String   | Required                | For tracking, reference                                    |
+| reuse_sent_index    | Sentence-level index within reuse document    | Integer  | Required                | For identifying sequential sentences for quote compilation |
+| original_id         | ID of the original sentence                   | String   | Required                | For tracking, reference, metadata linking                  |
+| original_text       | Text of the original sentence                 | String   | Required                | For reference                                              |
+| original_file       | Original document filename                    | String   | Required                | For tracking, reference, metadata linking                  |
+| original_sent_index | Sentence-level index within original document | Integer  | Required                | For identifying sequential sentences for quote compilation |
 
 Additional metadata for the corresponding reuse and original sentences will be included depending on the contents of the inoput sentence corpora.
 Additional reuse fields will follow `reuse_sent_index`.

--- a/src/remarx/quotation/pairs.py
+++ b/src/remarx/quotation/pairs.py
@@ -117,14 +117,11 @@ def load_sent_df(sentence_corpus: pathlib.Path, col_pfx: str = "") -> pl.DataFra
     - the sentence id field `sent_id` is renamed to `id`
 
     """
-    # NOTE: Since all required fields are strings, there's no need to infer schema
-    init_df = pl.read_csv(sentence_corpus, row_index_name="index", infer_schema=False)
     start_cols = ["index", "sent_id", "text"]
-    col_order = start_cols + [
-        col for col in init_df.columns if col not in set(start_cols)
-    ]
     return (
-        init_df.select(col_order)
+        # Since all required fields are strings, there's no need to infer schema
+        pl.read_csv(sentence_corpus, row_index_name="index", infer_schema=False)
+        .select(*start_cols, pl.all().exclude(start_cols))
         .rename({"sent_id": "id"})
         .rename(lambda x: f"{col_pfx}{x}")
     )
@@ -145,8 +142,8 @@ def compile_quote_pairs(
     Returns a dataframe with the following fields:
 
     - `match_score`: Estimated quality of the match
-    - All non-index fields from the reuse corpus (`reuse_id`, `reuse_text`, ...)
-    - All non-index fields from the original corpus (`original_id`, `original_text`, ...)
+    - All other fields in order from the reuse corpus except its row index
+    - All other fields in order from the original corpus except its row index
     """
     # Build and return quote pairs
     return (


### PR DESCRIPTION
**Associated Issue(s):** #212 

### Changes in this PR

- Updates `pairs.py` logic so it now carries any additional corpus metadata to the output CSV
- Some small updates to the docstrings in `pairs.py` so they render properly for mkdocs
- Updated technical design doc to reflect current development

### Notes

- The ordering of the fields for the output field have changed. Now, the ordering resembles the ordering of the final output within the technical design doc.

### Reviewer Checklist

@rlskoeser 
- [x] Check that the script runs locally.
- [x] Verify that the resulting output CSV has the additional fields and that the values of these fields have been preserved.

@tanhaow 
- [ ] Check that the script runs locally.
- [ ] Verify that the resulting output CSV has the additional fields and that the values of these fields have been preserved.