### PR TITLE
Configure mdformat to preserve numbers in ordered lists

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,6 +25,7 @@ repos:
         additional_dependencies:
           - mdformat-mkdocs
           - mdformat-frontmatter
+          - mdformat-pyproject # support configuration in pyproject.toml
         args: [--wrap, keep]
         # Temporarily exclude docs/api/index.md due because it messes up the formatting
         exclude: ^docs/api/index\.md$

--- a/DEVELOPERNOTES.md
+++ b/DEVELOPERNOTES.md
@@ -53,9 +53,9 @@ changes should not be included in the changelog unless it is substantial enough 
     - Via GitHub web interface: Go to your PR → Labels section in right sidebar → Click gear icon → Type "no changelog" and select it
     - Via GitHub CLI: Run `gh pr edit --add-label "no changelog"`
 
-1. The changelog check will automatically re-run and pass when the label is applied
+2. The changelog check will automatically re-run and pass when the label is applied
 
-1. Remove the label if you later decide the PR does need a changelog entry
+3. Remove the label if you later decide the PR does need a changelog entry
 
 ## Documentation
 

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ The app will not close automatically when you close the browser window or tab.
 To close the app:
 
 1. Type control+c within the terminal where the `remarx-app` command was run
-1. Then, when prompted, type `y` followed by enter.
+2. Then, when prompted, type `y` followed by enter.
 
 ## Documentation
 

--- a/docs/technical-design.md
+++ b/docs/technical-design.md
@@ -89,7 +89,7 @@ The core pipeline has two key inputs: reuse and original sentence corpora. Each 
 The core pipeline can be broken down into two key components:
 
 1. Sentence-Level Quote Detection
-1. Quote Compilation
+2. Quote Compilation
 
 **Sentence-Level Quote Detection.** This component takes an original and reuse sentence corpus as input and outputs a corpus of sentence-pairs corresponding to quotes.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,3 +146,6 @@ allow-direct-references = true
 
 [tool.uv]
 required-version = ">=0.8.6"
+
+[tool.mdformat]
+number = true


### PR DESCRIPTION
### Changes in this PR

- Update pre-commit hook to use `mdformat-pyproject` so we can configure mdformat in pyproject.toml
- Add tool configuration to pyproject.toml and configure mdformat to preserve numbers
- Updated markdown docs with mdformat, applying the new configuration


