### PR TITLE
Feature/improve tei handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@
 
 - ALTO input now uses block-level tags for filtering and section type in sentence corpus
     - By default, only includes blocks tagged as text, footnote, Title, or untagged
+- Refactored TEI input handling logic:
+    - Body text is now yield at the paragraph level
+    - Structural content (tables, math formulas, editorial divs) is filtered out in both body text and footnote text.
+    - Footnote labels (e.g., "1)", "2)") are removed from note text (but stored separately in case we still need them).
+    - Bug Fix: Inline footnote references now preserve trailing punctuation that follows `<ref type="footnote">`.
 
 ## [0.3.0] - 2025-10-27
 

--- a/src/remarx/sentence/corpus/tei_input.py
+++ b/src/remarx/sentence/corpus/tei_input.py
@@ -24,6 +24,7 @@ logger = logging.getLogger(__name__)
 
 TEI_NAMESPACE = "http://www.tei-c.org/ns/1.0"
 MATHML_NAMESPACE = "http://www.w3.org/1998/Math/MathML"  # Mathematical Markup Language (formulas in TEI)
+MATHML_MATH_TAG = f"{{{MATHML_NAMESPACE}}}math"
 
 # namespaced tags look like {http://www.tei-c.org/ns/1.0}tagname
 # create a named tuple of short tag name -> namespaced tag name
@@ -78,8 +79,6 @@ class TEIFootnote(BaseTEIXmlObject):
         parts: list[str] = []
         for node in self.node.xpath(".//text()"):
             parent = node.getparent()
-            if parent is None:
-                continue
             if any(
                 ancestor.tag == TEI_TAG.label and ancestor.get("type") == "footnote"
                 for ancestor in (parent, *parent.iterancestors())
@@ -171,7 +170,7 @@ class TEIPage(BaseTEIXmlObject):
         for candidate in (el, *el.iterancestors()):
             if candidate.tag in TEIPage.structural_tags:
                 return True
-            if candidate.tag == f"{{{MATHML_NAMESPACE}}}math":
+            if candidate.tag == MATHML_MATH_TAG:
                 return True
             if candidate.tag in (TEI_TAG.div, TEI_TAG.div2, TEI_TAG.div3):
                 div_type = candidate.attrib.get("type")
@@ -250,9 +249,6 @@ class TEIPage(BaseTEIXmlObject):
 
         for text_node in self.text_nodes:
             parent = text_node.getparent()
-            if parent is None:
-                continue
-
             if self.next_page and parent == self.next_page.node:
                 break
 

--- a/src/remarx/sentence/corpus/tei_input.py
+++ b/src/remarx/sentence/corpus/tei_input.py
@@ -23,6 +23,7 @@ logger = logging.getLogger(__name__)
 
 
 TEI_NAMESPACE = "http://www.tei-c.org/ns/1.0"
+MATHML_NAMESPACE = "http://www.w3.org/1998/Math/MathML"  # Mathematical Markup Language (formulas in TEI)
 
 # namespaced tags look like {http://www.tei-c.org/ns/1.0}tagname
 # create a named tuple of short tag name -> namespaced tag name
@@ -145,11 +146,10 @@ class TEIPage(BaseTEIXmlObject):
         Determine if *el* belongs to structural (layout) content—tables, figures, MathML, or editorial wrappers.
         These blocks describe presentation rather than body prose, so we skip them when building paragraph text.
         """
-        math_ns = "http://www.w3.org/1998/Math/MathML"
         for candidate in (el, *el.iterancestors()):
             if candidate.tag in TEIPage.structural_tags:
                 return True
-            if candidate.tag == f"{{{math_ns}}}math":
+            if candidate.tag == f"{{{MATHML_NAMESPACE}}}math":
                 return True
             if candidate.tag in (TEI_TAG.div, TEI_TAG.div2, TEI_TAG.div3):
                 div_type = candidate.attrib.get("type")

--- a/src/remarx/sentence/corpus/tei_input.py
+++ b/src/remarx/sentence/corpus/tei_input.py
@@ -260,7 +260,7 @@ class TEIPage(BaseTEIXmlObject):
                     and parent.get("type") == "footnote"
                     and parent.tail
                 ):
-                    tail_text = re.sub(r"\s*\n\s*", "\n", parent.tail).lstrip()
+                    tail_text = re.sub(r"\s+", " ", parent.tail).strip()
                     if tail_text:
                         paragraph_parts.append(tail_text)
                         char_offset += len(tail_text)

--- a/src/remarx/sentence/corpus/tei_input.py
+++ b/src/remarx/sentence/corpus/tei_input.py
@@ -306,6 +306,14 @@ class TEIPage(BaseTEIXmlObject):
             paragraph_parts.append(cleaned_text)
             char_offset += len(cleaned_text)
 
+            # Preserve tail text that follows skipped inline footnote references
+            if parent.tag == TEI_TAG.ref and parent.get("type") == "footnote":
+                tail = parent.tail or ""
+                tail = re.sub(r"\s+", " ", tail)
+                if tail:
+                    paragraph_parts.append(tail)
+                    char_offset += len(tail)
+
         chunk = flush()
         if chunk:
             yield chunk

--- a/tests/test_sentence/test_corpus/test_tei_input.py
+++ b/tests/test_sentence/test_corpus/test_tei_input.py
@@ -255,6 +255,17 @@ class TestTEIPage:
         standalone_p = Element("p")
         assert not TEIPage.is_footnote_content(standalone_p)
 
+    def test_is_structural_content_mathml(self):
+        # Add this test to pass coverage check
+        math_node = Element("{http://www.w3.org/1998/Math/MathML}math")
+        assert TEIPage.is_structural_content(math_node)
+
+    def test_is_structural_content_skip_div_type(self):
+        div = Element(TEI_TAG.div, type="editorialHead")
+        inner = Element(TEI_TAG.p)
+        div.append(inner)
+        assert TEIPage.is_structural_content(inner)
+
     def test_get_body_text_line_numbers_missing_lb_number(self):
         tei_doc = TEIDocument.init_from_file(TEST_TEI_WITH_FOOTNOTES_FILE)
         page_20 = next(p for p in tei_doc.pages if p.number == "20")

--- a/tests/test_sentence/test_corpus/test_tei_input.py
+++ b/tests/test_sentence/test_corpus/test_tei_input.py
@@ -191,6 +191,7 @@ class TestTEIPage:
         page_17 = next(p for p in tei_doc.all_pages if p.number == "17")
 
         footnote_text = page_17.get_footnote_text()
+        # assert we no longer have numbering like "1)" at the beginning of the footnote text
         assert footnote_text.startswith("Karl Marx:")
         assert "Nicholas Barbon" in footnote_text
         assert (
@@ -205,7 +206,9 @@ class TestTEIPage:
         # returns footnote xmlobject, which has a line number attribute
         assert footnotes[0].line_number == 17
         assert footnotes[1].line_number == 18
+        # the footnote label still includes the "1)" prefix
         assert footnotes[0].label.strip().startswith("1")
+        # but the footnote text itself no longer includes the "1)" prefix from the label
         assert footnotes[0].text.startswith("Karl Marx:")
 
     def test_get_footnote_text_delimiter(self):


### PR DESCRIPTION
**Associated Issue(s):** #269

### Changes in this PR
 Refactored TEI input handling logic to address problems pointed out in issue #269:
    - Body text is now yield at the paragraph level
    - Structural content (tables, math formulas, editorial divs) is filtered out in both body text and footnote text.
    - Footnote labels (e.g., "1)", "2)") are removed from note text (but stored separately in case we still need them).
    - Bug Fix: Inline footnote references now preserve trailing punctuation that follows `<ref type="footnote">`.


### Reviewer Checklist
- [ ] Review the code
Run TEI and check the output, check:
- [ ] Footnote labels are omitted
- [ ] Paragraphs that wrap pages correctly show `continued=True` label
- [ ] no more math formulas, tables, and title pages in the output (The output should look much cleaner now).
