### PR TITLE
Feature/cache sentence embeddings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -175,3 +175,6 @@ cython_debug/
 
 # built mkdocs site
 site/
+
+# sentence embedding cache
+/.remarx_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 - ALTO input now uses block-level tags for filtering and section type in sentence corpus
     - By default, only includes blocks tagged as text, footnote, Title, or untagged
 
+### Quotation detection
+
+- Embeddings now are cached locally in `.remarx_cache/embeddings/` directory to improve performance.
+
 ## [0.3.0] - 2025-10-27
 
 ### Sentence corpus creation


### PR DESCRIPTION
**Associated Issue(s):** #259

### Changes in this PR

- [ ] Added sentence embedding caching logic using `CRC32` hash to generate and store cache under `.remarx_cache/embeddings/` directory
- [ ] Enhanced logging to track embedding generation time and cache hit/miss events for better observability
- [ ] Updated `.gitignore`: Added `.remarx_cache/`

### Reviewer Checklist
- [ ] Review the code
- [ ] Run remarx and test if cache can be generated, stored, and read successfully

```
INFO:remarx.quotation.pairs::Now generating sentence embeddings
INFO:sentence_transformers.SentenceTransformer::Use pytorch device_name: mps
INFO:sentence_transformers.SentenceTransformer::Load pretrained SentenceTransformer: paraphrase-multilingual-mpnet-base-v2
INFO:remarx.quotation.embeddings::Generated 14,643 embeddings in 27.7 seconds
INFO:remarx.quotation.embeddings::Saved embeddings to cache file /Users/ht8933/Documents/dev/remarx/.remarx_cache/embeddings/f33a99af.npz
INFO:sentence_transformers.SentenceTransformer::Use pytorch device_name: mps
INFO:sentence_transformers.SentenceTransformer::Load pretrained SentenceTransformer: paraphrase-multilingual-mpnet-base-v2
INFO:remarx.quotation.embeddings::Generated 4,534 embeddings in 9.9 seconds
INFO:remarx.quotation.embeddings::Saved embeddings to cache file /Users/ht8933/Documents/dev/remarx/.remarx_cache/embeddings/cd142177.npz
INFO:remarx.quotation.pairs::Generated 19,177 sentence embeddings in 39.1 seconds
INFO:remarx.quotation.pairs::Created index with 14643 items and 768 dimensions in 0.4 seconds
INFO:remarx.quotation.pairs::Queried 4,534 sentence embeddings in 0.0 seconds
INFO:remarx.quotation.pairs::Identified 234 sentence pairs under score cutuff 0.225
INFO:remarx.quotation.pairs::Saved 234 quote pairs to /Users/ht8933/remarx_test_files/output/quote_pairs_Das_Kapital_MEGA_A2_B005-00_ETX_1896-97a XML Output-835pages.csv

INFO:remarx.quotation.pairs::Now generating sentence embeddings
INFO:remarx.quotation.embeddings::Loaded embeddings from cache file /Users/ht8933/Documents/dev/remarx/.remarx_cache/embeddings/f33a99af.npz
INFO:remarx.quotation.embeddings::Loaded embeddings from cache file /Users/ht8933/Documents/dev/remarx/.remarx_cache/embeddings/cd142177.npz
INFO:remarx.quotation.pairs::Generated 19,177 sentence embeddings in 0.1 seconds
INFO:remarx.quotation.pairs::Created index with 14643 items and 768 dimensions in 0.3 seconds
INFO:remarx.quotation.pairs::Queried 4,534 sentence embeddings in 0.0 seconds
INFO:remarx.quotation.pairs::Identified 284 sentence pairs under score cutuff 0.225
INFO:remarx.quotation.pairs::Saved 284 quote pairs to /Users/ht8933/remarx_test_files/output/quote_pairs_Das_Kapital_MEGA_A2_B005-00_ETX_1896-97a XML Output-835pages.csv
```