### PR TITLE
Revise changelog check to only run on open pull requests

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     # only run on open pull requests  (do not run if a label changes
     # on a closed PR, e.g., when "this sprint" label is removed)
-    if: ${{ github.event.pull_request.state != "closed" }}
+    if: github.event.pull_request.state == 'open'
     steps:
       - name: Check changelog
         uses: tarides/changelog-check-action@v3


### PR DESCRIPTION
**Associated Issue(s):** resolves #320 

### Changes in this PR

- Add a conditional to check that pull request state is open

### Notes

- To resolve case where the workflow runs and fails when labels are removed from closed PRs