### PR TITLE
Feature/rejoin hyphenated words

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Changed the sentence tokenizer from Stanza to spaCy, with default model `de_core_news_sm`.
 - Added `pip` as a dependency so spaCy models can be downloaded automatically when missing.
 - Added sentence filtering to exclude 1-2 word sentences and punctuation-only sentences from corpora to improve quote detection quality.
+- Rejoin end-of-line ASCII hyphenated words across tokenized sentence boundaries in the ALTO pipeline.
 
 ## 0.5.0
 

--- a/src/remarx/sentence/corpus/alto_input.py
+++ b/src/remarx/sentence/corpus/alto_input.py
@@ -375,8 +375,7 @@ class ALTOInput(FileInput):
         self, sents: list[tuple[int, str]]
     ) -> list[tuple[int, str]]:
         """
-        Merge adjacent tokenized sentence tuples when the first ends with an ASCII
-        hyphen and the next sentence begins with a lowercase alphabetic character.
+        Merge adjacent tokenized sentence tuples when the first ends with an ASCII hyphen.
         """
         merged: list[tuple[int, str]] = []
         i = 0
@@ -386,22 +385,13 @@ class ALTOInput(FileInput):
             text_i_stripped = text_i.rstrip()
             did_merge = False
             if i + 1 < n and text_i_stripped.endswith("-"):
-                # Candidate: next sentence exists and current ends with ASCII hyphen
+                # Join fragments split by end-of-line ASCII hyphen-minus.
                 _, next_text = sents[i + 1]
-                first_alpha = None
-                for ch in next_text[:256]:
-                    if ch.isalpha():
-                        first_alpha = ch
-                        break
-                # Only join when the continuation looks like a word fragment (first alpha exists and is lowercase)
-                if first_alpha is not None and first_alpha.islower():
-                    # Remove trailing hyphen and any whitespace, then join
-                    new_prefix = re.sub(r"-\s*$", "", text_i_stripped)
-                    new_text = new_prefix + next_text.lstrip()
-                    merged.append((start_i, new_text))
-                    # Skip the next sentence since it's been merged
-                    i += 2
-                    did_merge = True
+                new_prefix = re.sub(r"-\s*$", "", text_i_stripped)
+                new_text = new_prefix + next_text.lstrip()
+                merged.append((start_i, new_text))
+                i += 2
+                did_merge = True
             if not did_merge:
                 merged.append((start_i, text_i))
                 i += 1

--- a/src/remarx/sentence/corpus/alto_input.py
+++ b/src/remarx/sentence/corpus/alto_input.py
@@ -387,16 +387,20 @@ class ALTOInput(FileInput):
             text_i_stripped = text_i.rstrip()
             did_merge = False
             if i + 1 < n and text_i_stripped.endswith("-"):
+                # Candidate: next sentence exists and current ends with ASCII hyphen
                 _, next_text = sents[i + 1]
                 first_alpha = None
                 for ch in next_text[:256]:
                     if ch.isalpha():
                         first_alpha = ch
                         break
+                # Only join when the continuation looks like a word fragment (first alpha exists and is lowercase)
                 if first_alpha is not None and first_alpha.islower():
+                    # Remove trailing hyphen and any whitespace, then join
                     new_prefix = re.sub(r"-\s*$", "", text_i_stripped)
                     new_text = new_prefix + next_text.lstrip()
                     merged.append((start_i, new_text))
+                    # Skip the next sentence since it's been merged
                     i += 2
                     did_merge = True
             if not did_merge:

--- a/src/remarx/sentence/corpus/alto_input.py
+++ b/src/remarx/sentence/corpus/alto_input.py
@@ -375,9 +375,8 @@ class ALTOInput(FileInput):
         self, sents: list[tuple[int, str]]
     ) -> list[tuple[int, str]]:
         """
-        ALTO-only: merge adjacent tokenized sentence tuples when the first ends
-        with an ASCII hyphen-minus and the next sentence begins (after optional
-        punctuation/quotes) with a lowercase alphabetic character.
+        Merge adjacent tokenized sentence tuples when the first ends with an ASCII
+        hyphen and the next sentence begins with a lowercase alphabetic character.
         """
         merged: list[tuple[int, str]] = []
         i = 0

--- a/tests/test_sentence/test_corpus/test_alto_input.py
+++ b/tests/test_sentence/test_corpus/test_alto_input.py
@@ -490,29 +490,31 @@ def test_get_sentences_sequential(mock_segment_text: Mock):
 @patch.object(ALTOInput, "get_text")
 def test_alto_rejoin_hyphen_merge(mock_text, mock_segment, tmp_path: pathlib.Path):
     """
-    ALTO: If a tokenized sentence ends with an ASCII hyphen-minus and the next
-    sentence begins with a lowercase letter, the two should be merged.
+    Verify merging when a sentence ends with ASCII hyphen-minus and the
+    next sentence begins with a lowercase letter with real examples from ALTO.
     """
     mock_segment.return_value = [
-        (0, "Adler-"),
-        (6, "auge ist schön"),  # codespell:ignore
-    ]  # codespell:ignore
+        (0, "Was will und kann die materialistische Geschichts-"),
+        (40, "auffassung leisten?"),
+    ]
     mock_text.return_value = [{"meta": "x", "text": "ignored"}]
     alto_input = ALTOInput(input_file=tmp_path / "test.zip")
     results = list(alto_input.get_sentences())
-    assert any(r["text"].startswith("Adlerauge") for r in results)
+    assert any(
+        "Geschichtsauffassung" in r["text"].replace(" ", "")
+        or "Geschichtsauffassung" in r["text"]
+        for r in results
+    )
 
-
-@patch("remarx.sentence.corpus.alto_input.segment_text")
-@patch.object(ALTOInput, "get_text")
-def test_alto_rejoin_hyphen_no_merge(mock_text, mock_segment, tmp_path: pathlib.Path):
-    """
-    ALTO: If the continuation begins with an uppercase letter or the dash is
-    not an ASCII hyphen-minus, do not merge the sentences.
-    """
-    mock_segment.return_value = [(0, "Ende—"), (5, "Das ist neu")]  # codespell:ignore
+    mock_segment.return_value = [
+        (0, "Die nächsten Aufgaben der deutschen Gewerkschafts-"),
+        (50, "bewegung."),
+    ]
     mock_text.return_value = [{"meta": "x", "text": "ignored"}]
     alto_input = ALTOInput(input_file=tmp_path / "test.zip")
     results = list(alto_input.get_sentences())
-    assert any(r["text"].startswith("Ende") for r in results)  # codespell:ignore
-    assert any(r["text"].startswith("Das") for r in results)
+    assert any(
+        "Gewerkschaftsbewegung" in r["text"].replace(" ", "")
+        or "Gewerkschaftsbewegung" in r["text"]
+        for r in results
+    )

--- a/tests/test_sentence/test_corpus/test_alto_input.py
+++ b/tests/test_sentence/test_corpus/test_alto_input.py
@@ -469,7 +469,7 @@ def test_altoinput_error_empty_zip(tmp_path: pathlib.Path):
         list(alto_input.get_text())
 
 
-@patch("remarx.sentence.corpus.base_input.segment_text")
+@patch("remarx.sentence.corpus.alto_input.segment_text")
 def test_get_sentences_sequential(mock_segment_text: Mock):
     # patch in simple segmenter to split each input text in two
     mock_segment_text.side_effect = simple_segmenter


### PR DESCRIPTION
**Associated Issue(s):** resolves #279

### Changes in this PR
- ALTO-only: join end-of-line ASCII hyphen-minus across tokenized sentence boundaries in `ALTOInput.get_sentences`.
- Tests: added two real ALTO examples to `tests/test_sentence/test_corpus/test_alto_input.py`.

### Notes
- I carefully reviewed both TEI and ALTP corpus again. There are multiple types of hyphens and dashes in TEI, but luckily for ALTO we only have ASCII hyphen. So only ASCII hyphen-minus (`-`) is handled and rejoined.
- Added the logic in `alto_input`. I know overriding the base class for ALTO isn’t ideal — happy to change this if you have any suggestions.

### Reviewer checklist
- [ ] Review the code
- [ ] Check if the end-of-line hyphenated words now are rejoined.