### PR TITLE
Revise pyproject.toml and pre-commit hooks based on repo review

### DIFF
--- a/.github/ISSUE_TEMPLATE/software_release.md
+++ b/.github/ISSUE_TEMPLATE/software_release.md
@@ -4,7 +4,6 @@ about: Checklist for releasing new versions of remarx
 title: remarx release checklist
 labels: ''
 assignees: ''
-
 ---
 
 ## release prep

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
     hooks:
       # Run the linter
       - id: ruff-check
-        args: [--fix] # To enable lint fixes
+        args: [--fix, --show-fixes] # enable lint fixes
       # Run the formatter using configs in pyproject.toml
       - id: ruff-format
   # yamlfmt for formatting YAML files
@@ -17,7 +17,7 @@ repos:
     hooks:
       - id: yamlfmt
   # mdformat for formatting Markdown files
-  - repo: https://github.com/executablebooks/mdformat
+  - repo: https://github.com/hukkin/mdformat
     rev: 0.7.22
     hooks:
       - id: mdformat

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## 1.0.1
 
 - Updated technical design document to reflect 1.0 functionality
+- Revise pyproject.toml and pre-commit hooks based on [repo-review](https://learn.scientific-python.org/development/guides/repo-review/)
 
 ## 1.0
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,7 +10,7 @@ authors = [
 ]
 requires-python = ">=3.12"
 readme = "README.md"
-license = {text = "Apache-2"}
+license = {text = "Apache-2.0"}
 dynamic = ["version"]
 classifiers = [
   "Programming Language :: Python :: 3",
@@ -73,6 +73,11 @@ path = "src/remarx/__init__.py"
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+minversion = "8"
+log_level = "INFO"
+xfail_strict = true
+addopts = ["-ra", "--strict-config", "--strict-markers"]
+filterwarnings = ["error"]
 
 [tool.coverage.run]
 branch = true
@@ -94,10 +99,7 @@ exclude_lines = [
 directory = "coverage_html_report"
 
 [tool.ruff]
-# Always generate Python 3.12-compatible code
-target-version = "py312"
-# Configure src path so ruff import fixes can identify local imports
-src = [ "src" ]
+# uses python version from project.requires-python (3.13)
 # Also ignore the app notebook
 extend-exclude = [
   "src/remarx/app/corpus_builder.py",


### PR DESCRIPTION
The Scientific Python repo-review tool was included in the original technical design document, in the developer-facing notes, which I was reminded of when I revised it recently in #338 . 

Ran the review and made the recommended changes that were easy (does not address all flagged items).