### PR TITLE
Fix original_index misalignment when using multiple original corpus f…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # CHANGELOG
 
+## [develop]
+
+### Bug fixes
+
+- Fixed a bug where using multiple original corpus files produced incorrect quote pairs. When files were concatenated, each file's row index restarted from 0, creating duplicate values in `original_index`. The Voyager search returns globally unique positions, so the join matched against the wrong rows. Fixed by reassigning `original_index` as a globally unique range after concatenation. Introduced in #321, fixed in #362.
+
 ## [1.0.1] - 2026-01-20
 
 - Updated technical design document to reflect 1.0 functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,7 @@
 
 ## [1.0.2]
 
-### Bug fixes
-
-- Fixed a bug where using multiple original corpus files produced incorrect quote pairs (#362)
+- Bug fix: correct indexing for quotation detection when multiple original corpus files are selected as input ([#362](https://github.com/Princeton-CDH/remarx/issues/362))
 
 ## [1.0.1] - 2026-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,10 @@
 # CHANGELOG
 
-## [develop]
+## [1.0.2]
 
 ### Bug fixes
 
-- Fixed a bug where using multiple original corpus files produced incorrect quote pairs. When files were concatenated, each file's row index restarted from 0, creating duplicate values in `original_index`. The Voyager search returns globally unique positions, so the join matched against the wrong rows. Fixed by reassigning `original_index` as a globally unique range after concatenation. Introduced in #321, fixed in #362.
+- Fixed a bug where using multiple original corpus files produced incorrect quote pairs. When files were concatenated, each file's row index restarted from 0, creating duplicate values in `original_index`. The Voyager search returns globally unique positions, so the join matched against the wrong rows. Fixed by reassigning `original_index` as a globally unique range after concatenation.
 
 ## [1.0.1] - 2026-01-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### Bug fixes
 
-- Fixed a bug where using multiple original corpus files produced incorrect quote pairs. When files were concatenated, each file's row index restarted from 0, creating duplicate values in `original_index`. The Voyager search returns globally unique positions, so the join matched against the wrong rows. Fixed by reassigning `original_index` as a globally unique range after concatenation.
+- Fixed a bug where using multiple original corpus files produced incorrect quote pairs (#362)
 
 ## [1.0.1] - 2026-01-20
 

--- a/README.md
+++ b/README.md
@@ -13,6 +13,9 @@ published in _Die Neue Zeit_ between 1891 and 1918.
 [![codecov](https://codecov.io/gh/Princeton-CDH/remarx/graph/badge.svg?token=waqNjbHV8d)](https://codecov.io/gh/Princeton-CDH/remarx)
 [![Apache 2 License](https://img.shields.io/badge/license-Apache%20License%202.0-blue)](#license)
 
+> [!WARNING]
+> A bug in versions prior to 1.0.2 means that quotation candidates generated with multiple original files selected are not reliable. We *recommend upgrading to v1.0.2* and regenerating any data based on multiple original files.
+
 ## Basic Usage
 
 ### Installation

--- a/src/remarx/quotation/pairs.py
+++ b/src/remarx/quotation/pairs.py
@@ -207,7 +207,7 @@ def find_quote_pairs(
     # replace per-file index with a globally unique one across all files
     original_df = (
         pl.concat(original_dfs, how="diagonal")
-        .drop("original_index", strict=False)
+        .drop("original_index")
         .with_row_index("original_index")
     )
     original_vecs = np.concatenate(original_vecs)

--- a/src/remarx/quotation/pairs.py
+++ b/src/remarx/quotation/pairs.py
@@ -205,9 +205,10 @@ def find_quote_pairs(
     # combine dataframes and vectors, preserving order
     # use diagonal concat method, since fields may vary by input type
     # replace per-file index with a globally unique one across all files
-    combined_df = pl.concat(original_dfs, how="diagonal")
-    original_df = combined_df.with_columns(
-        pl.int_range(pl.len(), dtype=pl.UInt32).alias("original_index")
+    original_df = (
+        pl.concat(original_dfs, how="diagonal")
+        .drop("original_index", strict=False)
+        .with_row_index("original_index")
     )
     original_vecs = np.concatenate(original_vecs)
     reuse_df, reuse_vecs = load_sent_corpus(

--- a/src/remarx/quotation/pairs.py
+++ b/src/remarx/quotation/pairs.py
@@ -204,7 +204,11 @@ def find_quote_pairs(
         original_vecs.append(vecs)
     # combine dataframes and vectors, preserving order
     # use diagonal concat method, since fields may vary by input type
-    original_df = pl.concat(original_dfs, how="diagonal")
+    # replace per-file index with a globally unique one across all files
+    combined_df = pl.concat(original_dfs, how="diagonal")
+    original_df = combined_df.with_columns(
+        pl.int_range(pl.len(), dtype=pl.UInt32).alias("original_index")
+    )
     original_vecs = np.concatenate(original_vecs)
     reuse_df, reuse_vecs = load_sent_corpus(
         reuse_corpus, col_pfx="reuse_", show_progress_bar=show_progress_bar

--- a/tests/test_quotation/test_consolidate.py
+++ b/tests/test_quotation/test_consolidate.py
@@ -13,7 +13,6 @@ def test_identify_sequences():
         }
     )
     df_seq = identify_sequences(df, "idx", "group")
-    print(df_seq)
     # adds a group field based on the specified field
     assert "idx_group" in df_seq.columns
     assert "idx_sequential" in df_seq.columns

--- a/tests/test_quotation/test_pairs.py
+++ b/tests/test_quotation/test_pairs.py
@@ -253,7 +253,15 @@ def test_find_quote_pairs(
     assert mock_sent_pairs.call_args.args[2] == 0.225
     assert mock_sent_pairs.call_args.kwargs == {"show_progress_bar": False}
 
-    mock_compile_pairs.assert_called_once_with(orig_df, reuse_df, ["sent_pairs"])
+    # orig_df passed to compile_quote_pairs has original_index reassigned to be
+    # globally unique; check that the other columns match and index is correct
+    actual_orig_df = mock_compile_pairs.call_args.args[0]
+    assert (
+        actual_orig_df["original_text"].to_list() == orig_df["original_text"].to_list()
+    )
+    assert actual_orig_df["original_index"].to_list() == [0, 1]
+    assert mock_compile_pairs.call_args.args[1].equals(reuse_df)
+    assert mock_compile_pairs.call_args.args[2] == ["sent_pairs"]
     mock_consolidate_quotes.assert_not_called()
 
     # Consolidate enabled: should be called with result of compile pairs method

--- a/tests/test_quotation/test_pairs.py
+++ b/tests/test_quotation/test_pairs.py
@@ -232,7 +232,9 @@ def test_find_quote_pairs(
     orig_vecs = np.array([[5], [10]])
     reuse_vecs = np.array([[0], [1], [2]])
     # - mock sentence data
-    orig_df = pl.DataFrame({"original_text": ["some", "text"]})
+    orig_df = pl.DataFrame(
+        {"original_text": ["some", "text"], "original_index": [0, 1]}
+    )
     reuse_df = pl.DataFrame({"reuse_text": ["some", "other", "texts"]})
     mock_load_corpus.side_effect = [(orig_df, orig_vecs), (reuse_df, reuse_vecs)]
     mock_sent_pairs.return_value = ["sent_pairs"]
@@ -321,7 +323,7 @@ def test_find_quote_pairs(
 def test_find_quote_pairs_benchmark_logs(
     mock_load_corpus, mock_sent_pairs, mock_compile_pairs, caplog, tmp_path
 ):
-    df = pl.DataFrame({"text": ["some text"]})
+    df = pl.DataFrame({"text": ["some text"], "original_index": 1})
     # mock embeddings
     vecs = np.array([[5], [10]])
 

--- a/tests/test_quotation/test_pairs.py
+++ b/tests/test_quotation/test_pairs.py
@@ -376,6 +376,7 @@ def test_find_quote_pairs_integration(tmp_path):
     library work as expected in combination. This tests behavior that is otherwise
     masked by mocking.
     """
+    # second text in orig_sentences matches first in reuse_sentences
     test_orig = pl.DataFrame(
         data={"sent_id": ["B", "A", "C"], "text": orig_sentences}
     ).with_columns(corpus=pl.lit("original"))
@@ -412,14 +413,14 @@ def test_find_quote_pairs_integration(tmp_path):
 
 
 def test_find_quote_pairs_integration_multifile(tmp_path):
-    # same as above, but with multiple files for original content
-    # the match (sentence "A") is in the SECOND file, so its global index
-    # exceeds the first file's index range — this would silently fail before the fix
+    # same as above, but with original sentences split across multiple files
+    # - the second text in orig_sentences matches first in reuse_sentences
+    # - the match should be found regardless of input file order
     test_orig1 = pl.DataFrame(
-        data={"sent_id": ["B", "C"], "text": [orig_sentences[0], orig_sentences[2]]}
+        data={"sent_id": ["B", "A"], "text": orig_sentences[:2]}
     ).with_columns(corpus=pl.lit("original"))
     test_orig2 = pl.DataFrame(
-        data={"sent_id": ["A"], "text": [orig_sentences[1]]}
+        data={"sent_id": ["C"], "text": [orig_sentences[2]]}
     ).with_columns(corpus=pl.lit("original"))
 
     test_reuse = pl.DataFrame(
@@ -438,8 +439,15 @@ def test_find_quote_pairs_integration_multifile(tmp_path):
     find_quote_pairs([orig1_csv, orig2_csv], reuse_csv, out_csv, consolidate=False)
     # load and inspect to check for our one expected match
     results_df = pl.read_csv(out_csv)
+    assert results_df.height == 1
     result = results_df.to_dicts()[0]
-    assert result["reuse_id"] == "a"
-    assert result["original_id"] == "A"
+    assert (result["original_id"], result["reuse_id"]) == ("A", "a")
     # check with tolerance because 0 is a special case
     assert float(result["match_score"]) == pytest.approx(0, rel=1e-6, abs=1e-6)
+
+    # should get the same result no matter what order the input files are loaded
+    find_quote_pairs([orig2_csv, orig1_csv], reuse_csv, out_csv, consolidate=False)
+    results_df = pl.read_csv(out_csv)
+    assert results_df.height == 1
+    result = results_df.to_dicts()[0]
+    assert (result["original_id"], result["reuse_id"]) == ("A", "a")

--- a/tests/test_quotation/test_pairs.py
+++ b/tests/test_quotation/test_pairs.py
@@ -411,11 +411,13 @@ def test_find_quote_pairs_integration(tmp_path):
 
 def test_find_quote_pairs_integration_multifile(tmp_path):
     # same as above, but with multiple files for original content
+    # the match (sentence "A") is in the SECOND file, so its global index
+    # exceeds the first file's index range — this would silently fail before the fix
     test_orig1 = pl.DataFrame(
-        data={"sent_id": ["B", "A"], "text": orig_sentences[:2]}
+        data={"sent_id": ["B", "C"], "text": [orig_sentences[0], orig_sentences[2]]}
     ).with_columns(corpus=pl.lit("original"))
     test_orig2 = pl.DataFrame(
-        data={"sent_id": ["C"], "text": orig_sentences[2:]}
+        data={"sent_id": ["A"], "text": [orig_sentences[1]]}
     ).with_columns(corpus=pl.lit("original"))
 
     test_reuse = pl.DataFrame(


### PR DESCRIPTION
**Associated Issue(s):** resolves #362

### Bug

When multiple original corpus files were concatenated, each file's row index restarted from 0, creating duplicate values in `original_index`. The Voyager search returns globally unique positions (0 to N-1 across all files), so the join was matching against the wrong rows — producing incorrectly matched quote pairs.

There are two failure modes:
- If the global position falls within the first file's index range (0 to N-1), the join matches against the wrong sentence in the first file — producing a false positive
- If the global position exceeds the first file's range, the inner join silently drops the row — producing a false negative with no error or warning

In practice, results are heavily skewed toward the first original file passed. Matches from all other files are either dropped or mismatched.

Introduced in commit d89fa82 (#321).

### Changes in this PR

- Fix `original_index` misalignment: reassign as a globally unique range after `pl.concat`
- Update `test_find_quote_pairs_integration_multifile` to place the matched sentence in the second file, so its global index exceeds the first file's range — the scenario that was silently failing before the fix
- Update changelog

### Notes

- Bug only affects runs with multiple original files; single-file runs are unaffected
- All previously generated CSVs from multi-file runs should be considered invalid and re-run
- This slipped through because the existing multifile integration test used data small enough that the matched sentence's index happened to fall within the first file's range — the collision was never triggered
- The research team's review also did not catch it, partly because the output still contained many correct matches from the first file

### Reviewer Checklist

- [x] Verify fix logic in `pairs.py` — confirm `original_index` is reassigned after concat
- [x] Re-run quote detection with multiple original files and spot-check that matched pairs are semantically correct